### PR TITLE
add `get_linked_items` to retrieve and parse all linked database items for an experiment

### DIFF
--- a/mease_elabftw/__init__.py
+++ b/mease_elabftw/__init__.py
@@ -1,2 +1,3 @@
 from .metadata import get_metadata
+from .linked_items import get_linked_items
 from .experiments import list_experiments, upload_file

--- a/mease_elabftw/linked_items.py
+++ b/mease_elabftw/linked_items.py
@@ -1,0 +1,12 @@
+from .util import get_experiment, get_item
+from .parsing import html_to_dict
+
+
+def get_linked_items(experiment_id):
+    links = get_experiment(experiment_id).get("links", [])
+    items = []
+    for link in links:
+        item = get_item(link["itemid"])
+        item["data_dict"] = html_to_dict(item.get("body", ""))
+        items.append(item)
+    return items

--- a/mease_elabftw/parsing.py
+++ b/mease_elabftw/parsing.py
@@ -1,0 +1,24 @@
+from html.parser import HTMLParser
+
+
+class SimpleHtmlParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.strings = []
+
+    def handle_data(self, data):
+        self.strings.append(data)
+
+
+def html_to_strings(html):
+    parser = SimpleHtmlParser()
+    parser.feed(html)
+    return parser.strings
+
+
+def html_to_dict(html):
+    d = dict()
+    for string in html_to_strings(html):
+        pair = string.split(":")
+        d[pair[0].strip()] = pair[1].strip()
+    return d

--- a/mease_elabftw/tests/test_ids.py
+++ b/mease_elabftw/tests/test_ids.py
@@ -1,3 +1,4 @@
 valid_experiment = 156
 valid_experiment_no_metadata = 163
+valid_experiment_no_items = 163
 invalid_experiment = 9999999999999

--- a/mease_elabftw/tests/test_linked_items.py
+++ b/mease_elabftw/tests/test_linked_items.py
@@ -1,0 +1,60 @@
+import pytest
+import mease_elabftw
+import test_ids
+
+
+def test_get_linked_items():
+    items = mease_elabftw.get_linked_items(test_ids.valid_experiment)
+    assert len(items) == 3
+    assert items[0]["category"] == "dye"
+    assert items[0]["title"] == "DiO green"
+    d = items[0]["data_dict"]
+    assert len(d.items()) == 2
+    assert d["origin"] == "ThermoFisher"
+    assert d["catalog number"] == "V22886"
+    assert items[1]["category"] == "mouse line"
+    assert items[1]["title"] == "wild type"
+    d = items[1]["data_dict"]
+    assert len(d.items()) == 6
+    assert items[2]["category"] == "virus"
+    assert items[2]["title"] == "AAVretr Flpo"
+    d = items[2]["data_dict"]
+    assert len(d.items()) == 5
+    assert d["Virus in -80 storage"] == "AAVretr EF1a-Flpo"
+
+
+def test_get_linked_items_no_token(monkeypatch):
+    monkeypatch.delenv("ELABFTW_TOKEN")
+    with pytest.raises(Exception) as exception_info:
+        items = mease_elabftw.get_linked_items(test_ids.valid_experiment)
+    assert exception_info.type == RuntimeError
+    assert (
+        str(exception_info.value)
+        == "The ELABFTW_TOKEN environment variable needs to be set to your eLabFTW access token."
+    )
+
+
+def test_get_linked_items_invalid_token(monkeypatch):
+    monkeypatch.setenv("ELABFTW_TOKEN", "abc123")
+    with pytest.raises(Exception) as exception_info:
+        items = mease_elabftw.get_linked_items(test_ids.valid_experiment)
+    assert exception_info.type == RuntimeError
+    assert (
+        str(exception_info.value)
+        == "Could not connect to https://elabftw.uni-heidelberg.de - do you have a valid token?"
+    )
+
+
+def test_get_linked_items_invalid_id(monkeypatch):
+    with pytest.raises(Exception) as exception_info:
+        items = mease_elabftw.get_linked_items(test_ids.invalid_experiment)
+    assert exception_info.type == RuntimeError
+    assert (
+        str(exception_info.value)
+        == f"Experiment with id {test_ids.invalid_experiment} not found - do you have the correct id?"
+    )
+
+
+def test_get_linked_items_no_items():
+    items = mease_elabftw.get_linked_items(test_ids.valid_experiment_no_items)
+    assert len(items) == 0

--- a/mease_elabftw/util.py
+++ b/mease_elabftw/util.py
@@ -33,6 +33,14 @@ def get_experiment(experiment_id):
         handle_http_error(e, experiment_id)
 
 
+def get_item(item_id):
+    manager = get_manager()
+    try:
+        return manager.get_item(item_id)
+    except HTTPError as e:
+        handle_http_error(e, item_id)
+
+
 def get_experiments():
     manager = get_manager()
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 elabapy
 pynwb
+setuptools
+requests


### PR DESCRIPTION
- parses HTML body assuming key/value pairs are separated by a colon, and each pair is contained inside a html tag, e.g. `<p>`
