### PR TITLE
add example notebook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-
-  - repo: https://github.com/dfm/black_nbconvert
-    rev: v0.4.0
-    hooks:
-      - id: black_nbconvert
+      - id: black-jupyter
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.5.0

--- a/mease_elabftw/tests/test_cli.py
+++ b/mease_elabftw/tests/test_cli.py
@@ -7,10 +7,11 @@ def test_elabftw_list():
     result = runner.invoke(elabftw_list, args="Liam")
     assert result.exit_code == 0
     lines = result.output.split("\n")
-    assert len(lines) == 3
-    assert lines[0][:4] == "163:"
-    assert lines[1][:4] == "156:"
-    assert lines[2] == ""
+    assert len(lines) == 4
+    assert lines[0][:5] == "1128:"
+    assert lines[1][:4] == "163:"
+    assert lines[2][:4] == "156:"
+    assert lines[3] == ""
 
 
 def test_elabftw_list_no_token(monkeypatch):

--- a/mease_elabftw/tests/test_experiments.py
+++ b/mease_elabftw/tests/test_experiments.py
@@ -10,9 +10,9 @@ def test_list_experiments():
 
 def test_list_experiments_with_owner():
     lines = mease_elabftw.list_experiments("Liam")
-    assert len(lines) == 2
+    assert len(lines) == 3
     assert (
-        lines[0]
+        lines[1]
         == "163: test fake experiment without json metadata (Liam Keegan, 2021-10-07)"
     )
 

--- a/notebooks/get_experiments_and_upload_files.ipynb
+++ b/notebooks/get_experiments_and_upload_files.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e30c3874",
+   "metadata": {},
+   "source": [
+    "# mease-elabftw: get experiments and upload files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f32e4b6",
+   "metadata": {},
+   "source": [
+    "Note: you need to have exported a valid API token to use this notebook, e.g.\n",
+    "`export ELABFTW_TOKEN=abc123abc123abc123`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fb6b0fe",
+   "metadata": {},
+   "source": [
+    "### Import mease_elabftw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f88e6d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mease_elabftw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dce4556",
+   "metadata": {},
+   "source": [
+    "### List all experiments matching `owner`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a573b6e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mease_elabftw.list_experiments(\"Liam\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb799ef4",
+   "metadata": {},
+   "source": [
+    "### Get all experiments matching `owner` without an existing upload matching `exclude_filename`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3949d72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check if supplied experiment dict contains an upload with matching `real_name`\n",
+    "def uploads_contain_file(full_exp, filename):\n",
+    "    for upload in full_exp.get(\"uploads\", []):\n",
+    "        if filename in upload[\"real_name\"]:\n",
+    "            return True\n",
+    "    return False\n",
+    "\n",
+    "\n",
+    "# get all experiments belonging to `owner` that don't already have an upload matching `exclude_filename`\n",
+    "# returns a dict of {id : experiment_as_dict}\n",
+    "def get_and_filter_experiments(owner, exclude_filename):\n",
+    "    experiments = {}\n",
+    "    for exp in mease_elabftw.util.get_experiments():\n",
+    "        if owner in exp[\"fullname\"]:\n",
+    "            # need to get full experiment to check uploads\n",
+    "            full_exp = mease_elabftw.util.get_experiment(int(exp[\"id\"]))\n",
+    "            if not uploads_contain_file(full_exp, exclude_filename):\n",
+    "                experiments[int(exp[\"id\"])] = full_exp\n",
+    "    return experiments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8374cdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# e.g. get all experiments with owner that matches \"Liam\"\n",
+    "# excluding any that already have an uploaded file that matches \"hamming.txt\"\n",
+    "experiments = get_and_filter_experiments(\"Liam\", \"hamming.txt\")\n",
+    "print(experiments.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ce58a22",
+   "metadata": {},
+   "source": [
+    "### View metadata, linked item, etc from experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d859f13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiments[156]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db70450f",
+   "metadata": {},
+   "source": [
+    "## Upload a file to an experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e866865",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mease_elabftw.upload_file(experiment_id=1128, filename=\"test.txt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03ced54c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- list experiments by owner
- get experiments by owner, excluding those with an existing upload that matches supplied filename
- display dict containing all info from experiment
- upload a file to an experiment
